### PR TITLE
[202012][sonic_sfp]: prefer Config DB port index mapping over platform.json/port_config.ini

### DIFF
--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -56,6 +56,9 @@ class SfpUtilHelper(object):
         ports = ast.literal_eval(json.dumps(ports_data))
         for port in ports.keys():
             if "index" not in ports[port]:
+                print("Failed to get port config: invalid port entry {}: index field doesn't exist".format(port),
+                    file=sys.stderr
+                )
                 return None
 
         return ports

--- a/sonic_platform_base/sonic_sfp/sfputilhelper.py
+++ b/sonic_platform_base/sonic_sfp/sfputilhelper.py
@@ -48,10 +48,13 @@ class SfpUtilHelper(object):
         pass
 
     def get_port_mapping(self, asic_inst):
-        if multi_asic.is_multi_asic():
-            ports_data = multi_asic.get_port_table_for_asic("{}{}".format(multi_asic.ASIC_NAME_PREFIX, asic_inst))
-        else:
-            ports_data = multi_asic.get_port_table_for_asic(multi_asic.DEFAULT_NAMESPACE)
+        try:
+            if multi_asic.is_multi_asic():
+                ports_data = multi_asic.get_port_table_for_asic("{}{}".format(multi_asic.ASIC_NAME_PREFIX, asic_inst))
+            else:
+                ports_data = multi_asic.get_port_table_for_asic(multi_asic.DEFAULT_NAMESPACE)
+        except Exception as e:
+            return None
 
         ports = ast.literal_eval(json.dumps(ports_data))
         for port in ports.keys():


### PR DESCRIPTION
**Approach:**
1. Always use Config DB to get port mapping when it's available
2. When port mapping is missing in Config DB, use either `platform.json` or `port_config.ini`

Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>